### PR TITLE
onejs: add useEvent utility

### DIFF
--- a/definitions/global.d.ts
+++ b/definitions/global.d.ts
@@ -2,6 +2,7 @@ declare function require(path: string): any
 declare function importNamespace(path: string): any
 declare function getType(obj: any): any
 declare function onEngineReload(callback: Function): void
+declare function unregisterOnEngineReload(callback: Function): void
 declare function log(obj: any): void
 declare function error(obj: any): void
 declare function warn(obj: any): void

--- a/onejs/index.d.ts
+++ b/onejs/index.d.ts
@@ -1,4 +1,3 @@
 import { StateUpdater } from "preact/hooks";
-import { Signal } from "preact/signals";
 export declare function useEventfulState<T, K extends keyof T>(obj: T, propertyName: K, eventName?: string): [T[K], StateUpdater<T[K]>];
-export declare function eventfulSignal<T, K extends keyof T>(obj: T, propertyName: K, eventName?: string): Signal<T[K]>;
+export declare function useEvent<TEventName extends string, TCallback>(obj: Record<`add_${TEventName}` | `remove_${TEventName}`, (callback: TCallback) => void>, eventName: TEventName, callback: TCallback, dependencies?: any[]): void;


### PR DESCRIPTION
This is a proposal (with code sample) of a `useEvent` function that connects a JS callback to the firing of a C# event. It performs cleanup similar to `useEventfulState`, ensuring that callbacks do not remain registered on the C# side if the script engine reloads or the component unmounts.

Some differences between `useEvent` and `useEventfulState`:

- `useEvent` triggers a user-provided JS callback when the C# event fires
- `useEvent` is not intended for use with properties
- `useEvent` forwards dependencies to `useEffect`, allowing you to re-bind a new version of the callback if a dependency changes