### PR TITLE
fix IEnumerator<T> type definition

### DIFF
--- a/definitions/System/Collections/Generic/Generic.d.ts
+++ b/definitions/System/Collections/Generic/Generic.d.ts
@@ -1,13 +1,11 @@
-
-
 declare module "System/Collections/Generic" {
-    import { IEnumeratorAny } from "System/Collections"
-
     export interface IEnumerable<T = void> {
         GetEnumerator(): IEnumerator<T>
     }
 
     export interface IEnumerator<T = void> {
-        Current: T
+        get_Current: T
+        MoveNext(): boolean
+        Reset(): void
     }
 }


### PR DESCRIPTION
This PR updates the `IEnumerator<T>` type definition so it reflects the callable interface exposed by Jint. This includes:

- A `get_Current` property that replaces the `Current` property. `get_Current` is the true property name that is exposed via C# reflection.
- The `MoveNext` and `Reset` methods.

Note that `IEnumeratorAny` already correctly exposes the `get_Current` convention; this PR just aligns the type definition for the generic equivalent.