### PR TITLE
memo type should not require a comparison function

### DIFF
--- a/3rdparty/preact/compat/memo.d.ts
+++ b/3rdparty/preact/compat/memo.d.ts
@@ -1,4 +1,4 @@
-export declare function memo(c: any, comparer: any): {
+export declare function memo(c: any, comparer?: any): {
     (props: any): import("preact").VNode<any>;
     displayName: string;
     _forwarded: boolean;

--- a/3rdparty/preact/compat/memo.ts
+++ b/3rdparty/preact/compat/memo.ts
@@ -8,7 +8,7 @@ import { shallowDiffers } from './util';
  * @param {(prev: object, next: object) => boolean} [comparer] Custom equality function
  * @returns {import('./internal').FunctionComponent}
  */
-export function memo(c, comparer) {
+export function memo(c, comparer?: any) {
     function shouldUpdate(nextProps) {
         let ref = this.props.ref;
         let updateRef = ref == nextProps.ref;


### PR DESCRIPTION
The type annotation for `memo()` should not require a second comparison argument, since it [falls back to a shallow comparison](https://github.com/DragonGround/ScriptLib/blob/cee6678dcd9914f4491b805557e8fda77a709815/3rdparty/preact/compat/memo.js#L13-L16).