### PR TITLE
preact/compat/memo: forward types from wrapped component

### DIFF
--- a/3rdparty/preact/compat/memo.d.ts
+++ b/3rdparty/preact/compat/memo.d.ts
@@ -1,5 +1,2 @@
-export declare function memo(c: any, comparer?: any): {
-    (props: any): import("preact").VNode<any>;
-    displayName: string;
-    _forwarded: boolean;
-};
+import { FunctionComponent } from 'preact';
+export declare function memo<P = {}>(c: FunctionComponent<P>, comparer?: (prev: P, next: P) => boolean): FunctionComponent<P>;

--- a/3rdparty/preact/compat/memo.ts
+++ b/3rdparty/preact/compat/memo.ts
@@ -1,14 +1,14 @@
-import { createElement } from 'preact';
+import { FunctionComponent, createElement } from 'preact';
 import { shallowDiffers } from './util';
 
 /**
  * Memoize a component, so that it only updates when the props actually have
  * changed. This was previously known as `React.pure`.
- * @param {import('./internal').FunctionComponent} c functional component
- * @param {(prev: object, next: object) => boolean} [comparer] Custom equality function
- * @returns {import('./internal').FunctionComponent}
  */
-export function memo(c, comparer?: any) {
+export function memo<P = {}>(
+  c: FunctionComponent<P>,
+  comparer?: (prev: P, next: P) => boolean
+): FunctionComponent<P> {
     function shouldUpdate(nextProps) {
         let ref = this.props.ref;
         let updateRef = ref == nextProps.ref;


### PR DESCRIPTION
This change updates the type definition of `memo()` so it correctly forwards the prop types of the wrapped component. The type definition was copied from the upstream Preact codebase.