### PR TITLE
preact/signals: move enum-dependent code to .ts file

### DIFF
--- a/3rdparty/preact/signals/index.ts
+++ b/3rdparty/preact/signals/index.ts
@@ -10,8 +10,6 @@ import {
 } from "preact/signals-core";
 import {
 	VNode,
-	OptionsTypes,
-	HookFn,
 	Effect,
 	PropertyUpdater,
 	AugmentedComponent,
@@ -420,3 +418,26 @@ export function update<T extends SignalOrReactive>(
 	}
 }
 */
+
+const enum OptionsTypes {
+	HOOK = "_hook",
+	DIFF = "_diff",
+	DIFFED = "diffed",
+	RENDER = "_render",
+	CATCH_ERROR = "_catchError",
+	UNMOUNT = "unmount",
+}
+
+interface OptionsType {
+	[OptionsTypes.HOOK](component: Component, index: number, type: number): void;
+	[OptionsTypes.DIFF](vnode: VNode): void;
+	[OptionsTypes.DIFFED](vnode: VNode): void;
+	[OptionsTypes.RENDER](vnode: VNode): void;
+	[OptionsTypes.CATCH_ERROR](error: any, vnode: VNode, oldVNode: VNode): void;
+	[OptionsTypes.UNMOUNT](vnode: VNode): void;
+}
+
+type HookFn<T extends keyof OptionsType> = (
+	old: OptionsType[T],
+	...a: Parameters<OptionsType[T]>
+) => ReturnType<OptionsType[T]>;

--- a/3rdparty/preact/signals/internal.d.ts
+++ b/3rdparty/preact/signals/internal.d.ts
@@ -34,25 +34,3 @@ export interface VNode<P = any> extends PVNode<P> {
 	__np?: Record<string, any> | null;
 }
 
-export const enum OptionsTypes {
-	HOOK = "_hook",
-	DIFF = "_diff",
-	DIFFED = "diffed",
-	RENDER = "_render",
-	CATCH_ERROR = "_catchError",
-	UNMOUNT = "unmount",
-}
-
-export interface OptionsType {
-	[OptionsTypes.HOOK](component: Component, index: number, type: number): void;
-	[OptionsTypes.DIFF](vnode: VNode): void;
-	[OptionsTypes.DIFFED](vnode: VNode): void;
-	[OptionsTypes.RENDER](vnode: VNode): void;
-	[OptionsTypes.CATCH_ERROR](error: any, vnode: VNode, oldVNode: VNode): void;
-	[OptionsTypes.UNMOUNT](vnode: VNode): void;
-}
-
-export type HookFn<T extends keyof OptionsType> = (
-	old: OptionsType[T],
-	...a: Parameters<OptionsType[T]>
-) => ReturnType<OptionsType[T]>;


### PR DESCRIPTION
This change moves some type definitions in `3rdparty/preact/signals/internal.d.ts` into the corresponding `.ts` file. Specifically, it moves an `enum` declaration from `.d.ts` to `.ts`, and also moves any dependent types.

The reason is that `enum` is subtly broken in `.d.ts` files, even if it is `const enum`. This doesn't cause issues for `tsc`, but it does cause problems if you're bundling ScriptLib using the source `.ts` files via a bundler such as esbuild.

To my mind, `const enum` ought to be fine in a `.d.ts` file, but the maintainer of esbuild [seems to disagree](https://github.com/evanw/esbuild/issues/128#issuecomment-1002341244).

It is possible that downstream code is including the types extracted from `internal.d.ts`, but I think the risk is low. Those types don't seem to be very useful outside of `signals/index.ts`, so it shouldn't break anything unless the downstream code was doing something really weird.