### PR TITLE
List<T> should extend IEnumerable<T>

### DIFF
--- a/definitions/System/Collections/Generic/List.d.ts
+++ b/definitions/System/Collections/Generic/List.d.ts
@@ -2,12 +2,9 @@
 
 declare module "System/Collections/Generic" {
 
-    export interface ListEnumerator<T> {
+    export interface ListEnumerator<T> extends IEnumerator<T> {
         Current: T
-
-        MoveNext(): boolean
         Dispose(): void
-
     }
 
     export class List<T> {


### PR DESCRIPTION
This change ensures that the `List<T>` type definition satisfies `IEnumerable<T>`.

Note that `List<T>`'s type definition keeps the original `Count` property. `List<T>`'s CLR interface implements `Current` as an explicit property that is accessible via Jint, whereas other objects that satisfy `IEnumerable<T>` on the C# side may only provide `get_Current` to Jint.