### PR TITLE
tweaks for satisfying typechecker

### DIFF
--- a/3rdparty/lodash/internal/nodeTypes.ts
+++ b/3rdparty/lodash/internal/nodeTypes.ts
@@ -12,7 +12,7 @@ const freeModule = freeExports && typeof module === 'object' && module !== null 
 const moduleExports = freeModule && freeModule.exports === freeExports
 
 /** Detect free variable `process` from Node.js. */
-const freeProcess = moduleExports && freeGlobal.process
+const freeProcess = moduleExports && freeGlobal && freeGlobal.process
 
 /** Used to access faster Node.js helpers. */
 const nodeTypes = ((() => {

--- a/3rdparty/preact/signals-core/index.ts
+++ b/3rdparty/preact/signals-core/index.ts
@@ -660,4 +660,4 @@ function effect(compute: () => unknown): () => void {
 	return effect._dispose.bind(effect);
 }
 
-export { signal, computed, effect, batch, Signal, ReadonlySignal };
+export { signal, computed, effect, batch, Signal, type ReadonlySignal };

--- a/3rdparty/preact/signals/index.ts
+++ b/3rdparty/preact/signals/index.ts
@@ -22,6 +22,29 @@ const HAS_PENDING_UPDATE = 1 << 0;
 const HAS_HOOK_STATE = 1 << 1;
 const HAS_COMPUTEDS = 1 << 2;
 
+const enum OptionsTypes {
+	HOOK = "_hook",
+	DIFF = "_diff",
+	DIFFED = "diffed",
+	RENDER = "_render",
+	CATCH_ERROR = "_catchError",
+	UNMOUNT = "unmount",
+}
+
+interface OptionsType {
+	[OptionsTypes.HOOK](component: Component, index: number, type: number): void;
+	[OptionsTypes.DIFF](vnode: VNode): void;
+	[OptionsTypes.DIFFED](vnode: VNode): void;
+	[OptionsTypes.RENDER](vnode: VNode): void;
+	[OptionsTypes.CATCH_ERROR](error: any, vnode: VNode, oldVNode: VNode): void;
+	[OptionsTypes.UNMOUNT](vnode: VNode): void;
+}
+
+type HookFn<T extends keyof OptionsType> = (
+	old: OptionsType[T],
+	...a: Parameters<OptionsType[T]>
+) => ReturnType<OptionsType[T]>;
+
 // Install a Preact options hook
 function hook<T extends OptionsTypes>(hookName: T, hookFn: HookFn<T>) {
 	// @ts-ignore-next-line private options hooks usage
@@ -418,26 +441,3 @@ export function update<T extends SignalOrReactive>(
 	}
 }
 */
-
-const enum OptionsTypes {
-	HOOK = "_hook",
-	DIFF = "_diff",
-	DIFFED = "diffed",
-	RENDER = "_render",
-	CATCH_ERROR = "_catchError",
-	UNMOUNT = "unmount",
-}
-
-interface OptionsType {
-	[OptionsTypes.HOOK](component: Component, index: number, type: number): void;
-	[OptionsTypes.DIFF](vnode: VNode): void;
-	[OptionsTypes.DIFFED](vnode: VNode): void;
-	[OptionsTypes.RENDER](vnode: VNode): void;
-	[OptionsTypes.CATCH_ERROR](error: any, vnode: VNode, oldVNode: VNode): void;
-	[OptionsTypes.UNMOUNT](vnode: VNode): void;
-}
-
-type HookFn<T extends keyof OptionsType> = (
-	old: OptionsType[T],
-	...a: Parameters<OptionsType[T]>
-) => ReturnType<OptionsType[T]>;

--- a/onejs/comps/index.tsx
+++ b/onejs/comps/index.tsx
@@ -1,2 +1,2 @@
-export { SwitchProps, Switch, ToggleProps, Toggle, DiamondToggle } from "./Toggle"
-export { ListboxProps, Listbox, SelectProps, Select } from "./Select"
+export { type SwitchProps, Switch, type ToggleProps, Toggle, DiamondToggle } from "./Toggle"
+export { type ListboxProps, Listbox, type SelectProps, Select } from "./Select"


### PR DESCRIPTION
These changes satisfy the `tsc` typechecker assuming that the [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules) flag is enabled. This flag is recommended when using TypeScript alongside a bundler such as webpack or esbuild.

The changes should have no impact on the behavior of the compiled JS. See inline for specific comments on why certain changes were necessary.