### PR TITLE
element key: more flexible type definition

### DIFF
--- a/definitions/jsx.d.ts
+++ b/definitions/jsx.d.ts
@@ -19,7 +19,7 @@ declare module "preact/jsx" {
         export interface VisualElement {
             id?: string
             ref?: Ref<any>
-            key?: string
+            key?: string | number
             disabled?: boolean
 
             children?: (string | number | boolean | Element | null | undefined) | (string | number | boolean | Element | null | undefined)[]


### PR DESCRIPTION
This change relaxes the typing of element `key` properties so they align with the official [React type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L131). I.e., if they are defined at all, keys can be strings or numbers.

Preact's own type definitions are murky. The [`createVNode` docstring](https://github.com/preactjs/preact/blob/0cdc9dfdf0c94ff30e8892514087cd765b1ae144/src/create-element.js#L49) allows `string | number | null`. It's unclear why `null` is allowed. Their [official `jsx.d.ts`](https://github.com/preactjs/preact/blob/0cdc9dfdf0c94ff30e8892514087cd765b1ae144/src/index.d.ts#L38) is equivalent to `any`, which seems like a bug to me.