### PR TITLE
Modify events' signature to be more restrictive

### DIFF
--- a/onejs/index.js
+++ b/onejs/index.js
@@ -1,20 +1,20 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useEvent = exports.useEventfulState = void 0;
+exports.useRefEvent = exports.useEvent = exports.useEventfulState = void 0;
 var hooks_1 = require("preact/hooks");
 function useEventfulState(obj, propertyName, eventName) {
     var _a = (0, hooks_1.useState)(obj[propertyName]), val = _a[0], setVal = _a[1];
     var _b = (0, hooks_1.useState)({}), updateState = _b[1];
     var forceUpdate = (0, hooks_1.useCallback)(function () { return updateState({}); }, []);
-    eventName = eventName || "On" + String(propertyName) + "Changed";
+    eventName || (eventName = "On".concat(propertyName, "Changed"));
     var addEventFunc = obj["add_".concat(eventName)];
     var removeEventFunc = obj["remove_".concat(eventName)];
     if (!addEventFunc || !removeEventFunc)
         throw new Error("[useEventfulState] The object does not have an event named ".concat(eventName));
-    var onValueChangedCallback = function (v) {
+    function onValueChangedCallback(v) {
         setVal(v);
         forceUpdate();
-    };
+    }
     function removeHandler() {
         removeEventFunc.call(obj, onValueChangedCallback);
     }
@@ -26,17 +26,16 @@ function useEventfulState(obj, propertyName, eventName) {
             unregisterOnEngineReload(removeHandler);
         };
     }, []);
-    var setValWrapper = function (v) {
+    function setValWrapper(v) {
         obj[propertyName] = v;
-    };
+    }
     return [val, setValWrapper];
 }
 exports.useEventfulState = useEventfulState;
 function useEvent(obj, eventName, callback, dependencies) {
     if (dependencies === void 0) { dependencies = []; }
-    var remove = obj["remove_".concat(eventName)].bind(obj);
     function removeHandler() {
-        remove(callback);
+        obj["remove_".concat(eventName)](callback);
     }
     (0, hooks_1.useEffect)(function () {
         obj["add_".concat(eventName)](callback);
@@ -48,3 +47,20 @@ function useEvent(obj, eventName, callback, dependencies) {
     }, dependencies);
 }
 exports.useEvent = useEvent;
+function useRefEvent(ref, eventName, callback, dependencies) {
+    if (dependencies === void 0) { dependencies = []; }
+    function removeHandler() {
+        var obj = ref.current.ve;
+        obj["remove_".concat(eventName)](callback);
+    }
+    (0, hooks_1.useEffect)(function () {
+        var obj = ref.current.ve;
+        obj["add_".concat(eventName)](callback);
+        onEngineReload(removeHandler);
+        return function () {
+            removeHandler();
+            unregisterOnEngineReload(removeHandler);
+        };
+    }, dependencies);
+}
+exports.useRefEvent = useRefEvent;

--- a/onejs/index.ts
+++ b/onejs/index.ts
@@ -1,47 +1,66 @@
-import { StateUpdater, useCallback, useEffect, useState } from "preact/hooks"
+import {
+  MutableRef,
+  StateUpdater,
+  useCallback,
+  useEffect,
+  useState,
+} from "preact/hooks"
 
 /**
- * A convenience hook that, like useState(), returns a stateful value and a function to update it. This one ties the value to a property on a C# object. It takes care of setting up and cleaning up the C# value changed event automatically. Refer here for more info: https://onejs.com/dataflow#reducing-boilerplates
- * 
+ * A convenience hook that, like useState(), returns a stateful value and a function to update it.
+ * This one ties the value to a property on a C# object.
+ * It takes care of setting up and cleaning up the C# value changed event automatically.
+ * Refer here for more info: https://onejs.com/dataflow#reducing-boilerplates
+ *
  * @param obj The C# object containing the property to be observed
  * @param propertyName The name of the property to be observed
  * @param eventName The name of the event to be observed. If not specified, it defaults to "On{propertyName}Changed"
- * @returns 
+ * @returns
  */
-export function useEventfulState<T, K extends keyof T>(obj: T, propertyName: K, eventName?: string): [T[K], StateUpdater<T[K]>] {
-    const [val, setVal] = useState(obj[propertyName] as unknown as T[K])
-    const [, updateState] = useState({})
-    const forceUpdate = useCallback(() => updateState({}), [])
+export function useEventfulState<
+  T extends {
+    [k in K | `add_${E}` | `remove_${E}`]: k extends `add_${E}` | `remove_${E}`
+      ? (handler: (value: T[K]) => any) => void
+      : any
+  },
+  K extends string & keyof T,
+  E extends string = `On${K}Changed`
+>(obj: T, propertyName: K, eventName?: E): [T[K], StateUpdater<T[K]>] {
+  const [val, setVal] = useState<T[K]>(obj[propertyName])
+  const [, updateState] = useState({})
+  const forceUpdate = useCallback(() => updateState({}), [])
 
-    eventName = eventName || "On" + String(propertyName) + "Changed"
-    let addEventFunc = obj[`add_${eventName}`] as Function
-    let removeEventFunc = obj[`remove_${eventName}`] as Function
+  eventName ||= `On${propertyName}Changed` as E
+  const addEventFunc = obj[`add_${eventName}`]
+  const removeEventFunc = obj[`remove_${eventName}`]
 
-    if (!addEventFunc || !removeEventFunc)
-        throw new Error(`[useEventfulState] The object does not have an event named ${eventName}`)
+  if (!addEventFunc || !removeEventFunc)
+    throw new Error(
+      `[useEventfulState] The object does not have an event named ${eventName}`
+    )
 
-    let onValueChangedCallback = function (v) {
-        setVal(v)
-        forceUpdate()
+  function onValueChangedCallback(v: T[K]) {
+    setVal(v)
+    forceUpdate()
+  }
+
+  function removeHandler() {
+    removeEventFunc.call(obj, onValueChangedCallback)
+  }
+
+  useEffect(() => {
+    addEventFunc.call(obj, onValueChangedCallback)
+    onEngineReload(removeHandler)
+    return () => {
+      removeHandler()
+      unregisterOnEngineReload(removeHandler)
     }
-
-    function removeHandler() {
-        removeEventFunc.call(obj, onValueChangedCallback)
-    }
-
-    useEffect(() => {
-        addEventFunc.call(obj, onValueChangedCallback)
-        onEngineReload(removeHandler)
-        return () => {
-            removeHandler()
-            unregisterOnEngineReload(removeHandler)
-        }
-    }, [])
-    const setValWrapper = (v) => {
-        obj[propertyName] = v
-        // setVal(v) // No need to set the state here in JS. The event handling stuff above will do.
-    }
-    return [val, setValWrapper]
+  }, [])
+  function setValWrapper(v: T[K]) {
+    obj[propertyName] = v
+    // setVal(v) // No need to set the state here in JS. The event handling stuff above will do.
+  }
+  return [val, setValWrapper]
 }
 
 /**
@@ -53,76 +72,73 @@ export function useEventfulState<T, K extends keyof T>(obj: T, propertyName: K, 
  * @param dependencies: The dependencies to pass to useEffect. Previous versions
  * of the callback will be cleaned up any dependency changes.
  */
-export function useEvent<TEventName extends string, TCallback>(
-    obj: HasCSharpEventBase<TEventName, TCallback>,
-    eventName: TEventName,
-    callback: TCallback,
-    dependencies: any[] = []
+export function useEvent<
+  T extends {
+    [k in `add_${E}` | `remove_${E}`]: (handler: (...args: any) => any) => void
+  },
+  E extends string
+>(
+  obj: T,
+  eventName: E,
+  callback: InferEventHandler<T[`add_${E}`]> &
+    InferEventHandler<T[`remove_${E}`]>,
+  dependencies: any[] = []
 ) {
-    const remove = obj[`remove_${eventName}`].bind(obj)
-    function removeHandler() {
-        remove(callback)
-    }
+  function removeHandler() {
+    obj[`remove_${eventName}`](callback)
+  }
 
-    useEffect(() => {
-        obj[`add_${eventName}`](callback)
-        onEngineReload(removeHandler)
-        return () => {
-            removeHandler()
-            unregisterOnEngineReload(removeHandler)
-        }
-    }, dependencies)
+  useEffect(() => {
+    obj[`add_${eventName}`](callback)
+    onEngineReload(removeHandler)
+    return () => {
+      removeHandler()
+      unregisterOnEngineReload(removeHandler)
+    }
+  }, dependencies)
 }
 
 /**
- * Describes a C# class or struct that contains a property that is a C# event.
- * For example, given a C# class that declares an event called `OnValueChanged`
- * whose delegates accept a single parameter of type `int`, you can declare the
- * type as follows:
- *
- *   type MyType = HasCsharpEvent<"OnValueChanged", number> & {
- *     // other properties...
- *   }
- * 
- * For event delegates that take more than one value, see related types
- * `HasCsharpEvent2` and `HasCsharpEvent3`.
+ * Similar to useEvent() but accepts a ref that references the C# object instead.
+ * Run a callback when a C# event fires. The callback will be cleaned up on
+ * unmount and when the OneJS engine reloads.
+ * @param ref The ref that contains the C# object.
+ * @param eventName The variable name of the C# event.
+ * @param callback The callback to run when the event fires.
+ * @param dependencies: The dependencies to pass to useEffect. Previous versions
+ * of the callback will be cleaned up any dependency changes.
  */
-export type HasCsharpEvent<EventName extends string, TVal> = HasCSharpEventBase<
-  EventName,
-  (val: TVal) => void
->;
+export function useRefEvent<
+  T extends {
+    [k in `add_${E}` | `remove_${E}`]: (handler: (...args: any) => any) => void
+  },
+  E extends string
+>(
+  ref: MutableRef<Dom>,
+  eventName: E,
+  callback: InferEventHandler<T[`add_${E}`]> &
+    InferEventHandler<T[`remove_${E}`]>,
+  dependencies: any[] = []
+) {
+  function removeHandler() {
+    const obj = ref.current.ve as T
+    obj[`remove_${eventName}`](callback)
+  }
 
-export type HasCsharpEvent2<
-  EventName extends string,
-  TVal1,
-  TVal2
-> = HasCSharpEventBase<EventName, (val1: TVal1, val2: TVal2) => void>;
+  useEffect(() => {
+    const obj = ref.current.ve as T
+    obj[`add_${eventName}`](callback)
+    onEngineReload(removeHandler)
 
-export type HasCsharpEvent3<
-  EventName extends string,
-  TVal1,
-  TVal2,
-  TVal3
-> = HasCSharpEventBase<
-  EventName,
-  (val1: TVal1, val2: TVal2, val3: TVal3) => void
->;
+    return () => {
+      removeHandler()
+      unregisterOnEngineReload(removeHandler)
+    }
+  }, dependencies)
+}
 
-/**
- * A type that describes a C# class or struct that contains the following
- * properties/fields that conform to the useEventfulState() protocol:
- * 
- * - a property with an arbitrary name and type
- * - a C# event named `On{PropertyName}Changed`, whose delegate accepts a single
- *   parameter of the same type as the property
- */
-export type HasEventfulProperty<PropName extends string, TVal> = Record<
-  PropName,
-  TVal
-> &
-  HasCsharpEvent<`On${Capitalize<PropName>}Changed`, TVal>;
-
-type HasCSharpEventBase<EventName extends string, TCallback> = Record<
-  `add_${EventName}` | `remove_${EventName}`,
-  (handler: TCallback) => void
->;
+type InferEventHandler<T> = T extends (
+  handler: (...args: infer P) => infer R
+) => void
+  ? (...args: P) => R
+  : never


### PR DESCRIPTION
+ Modified events' signature for better type checking.
+ Removed `HasCSharpEventBase` because the event handler signature can be inferred using `InferEventHandler`.
+ Add `useRefEvent`. It is similar to `useEvent` but accepts a `MutableRef` that references the C# object instead.