### PR TITLE
Fix tailwind transform utilities

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "semi": false,
+    "tabWidth": 4
+}

--- a/onejs-tw-config.js
+++ b/onejs-tw-config.js
@@ -1,19 +1,19 @@
-const defaultTheme = require('tailwindcss/defaultTheme')
+const defaultTheme = require("tailwindcss/defaultTheme")
 const plugin = require("tailwindcss/plugin")
 
 let theme = rem2px(defaultTheme)
 theme.extend = {
     transitionTimingFunction: {
         DEFAULT: "ease-in-out",
-        "in-out": "ease-in-out"
-    }
+        "in-out": "ease-in-out",
+    },
 }
 exports.theme = theme
 
 exports.paths = ["./ScriptLib/onejs/comps/**/*.js", "./Samples/**/*.js"]
 
 exports.plugins = [
-    plugin(function ({ addUtilities, matchUtilities, addBase, theme }) {
+    plugin(function ({ addUtilities, matchUtilities, theme }) {
         addUtilities({
             ".bg-crop": {
                 "-unity-background-scale-mode": "scale-and-crop",
@@ -43,47 +43,56 @@ exports.plugins = [
                 top: "0px",
                 bottom: "0px",
                 left: "0px",
-                right: "0px"
-            }
+                right: "0px",
+            },
+            ".transition-none": { "transition-property": "none" },
+            ".transition-all": {
+                "transition-property": "all",
+                "transition-duration": "150ms",
+            },
+            ".scale-none": { scale: "none" },
+            ".rotate-none": { rotate: "none" },
         })
 
         matchUtilities(
             {
-                transition: (value) => ({
-                    "transition-property": value,
-                }),
-                scale: (value) => ({
-                    "scale": value
-                }),
-                translate: (value) => ({
-                    "translate": value,
-                }),
-                "translate-x": (value) => ({
-                    "translate": `${value} 0`,
-                }),
-                "translate-y": (value) => ({
-                    "translate": `0 ${value}`,
-                }),
-                rotate: (value) => ({
-                    "rotate": value,
-                }),
+                translate: (value) => ({ translate: value }),
+                "translate-x": (value) => ({ translate: `${value} 0` }),
+                "translate-y": (value) => ({ translate: `0 ${value}` }),
             },
             {
-                values: {
-                    ...theme('scale'),
-                    ...theme('translate'),
-                    ...theme('translate-x'),
-                    ...theme('translate-y'),
-                    ...theme('rotate'),
-                },
+                supportsNegativeValues: true,
+                values: theme("translate"),
             }
         )
-    })
+
+        matchUtilities(
+            {
+                scale: (value) => ({ scale: value }),
+                "scale-x": (value) => ({ scale: `${value} 0` }),
+                "scale-y": (value) => ({ scale: `0 ${value}` }),
+            },
+            {
+                supportsNegativeValues: true,
+                values: theme("scale"),
+            }
+        )
+
+        matchUtilities(
+            {
+                rotate: (value) => ({ rotate: value }),
+            },
+            {
+                supportsNegativeValues: true,
+                values: theme("rotate"),
+            }
+        )
+    }),
 ]
 
 exports.corePlugins = {
     // USS cannot support dynamic custom properties within rgb()
-    // which is what is used by Tailwind for opacity scales 
+    // which is what is used by Tailwind for opacity scales
     transitionProperty: false,
     backdropOpacity: false,
     backgroundOpacity: false,
@@ -101,12 +110,13 @@ exports.corePlugins = {
  * Utilities
  */
 
-function rem2px(input, fontSize = 16) { // rem is not supported in USS
+// rem is not supported in USS
+function rem2px(input, fontSize = 16) {
     if (input == null) {
         return input
     }
     switch (typeof input) {
-        case 'object':
+        case "object":
             if (Array.isArray(input)) {
                 return input.map((val) => rem2px(val, fontSize))
             }
@@ -114,17 +124,21 @@ function rem2px(input, fontSize = 16) { // rem is not supported in USS
             for (const key in input) {
                 ret[key] = rem2px(input[key], fontSize)
             }
-            return ret;
-        case 'string':
+            return ret
+        case "string":
             return input.replace(
                 /(\d*\.?\d+)rem$/,
-                (_, val) => `${parseFloat(val) * fontSize}px`,
+                (_, val) => `${parseFloat(val) * fontSize}px`
             )
-        case 'function':
-            return eval(input.toString().replace(
-                /(\d*\.?\d+)rem/g,
-                (_, val) => `${parseFloat(val) * fontSize}px`,
-            ))
+        case "function":
+            return eval(
+                input
+                    .toString()
+                    .replace(
+                        /(\d*\.?\d+)rem/g,
+                        (_, val) => `${parseFloat(val) * fontSize}px`
+                    )
+            )
         default:
             return input
     }


### PR DESCRIPTION
+ Fixed dynamic utilities for `translate`, `scale`, `rotate`.
+ Removed `transition` from dynamic utilities. Instead, added static utilities: `transition-none` and `transition-all`.
+ Added `.prettierrc` to unify coding style.