### PR TITLE
Fix useEventfulState

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+    "printWidth": 120,
     "semi": false,
     "tabWidth": 4
 }

--- a/onejs/index.js
+++ b/onejs/index.js
@@ -3,42 +3,49 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.useRefEvent = exports.useEvent = exports.useEventfulState = void 0;
 var hooks_1 = require("preact/hooks");
 function useEventfulState(obj, propertyName, eventName) {
-    var _a = (0, hooks_1.useState)(obj[propertyName]), val = _a[0], setVal = _a[1];
-    eventName || (eventName = "On".concat(propertyName, "Changed"));
-    var addEventFunc = obj["add_".concat(eventName)];
-    var removeEventFunc = obj["remove_".concat(eventName)];
-    if (!addEventFunc || !removeEventFunc)
-        throw new Error("[useEventfulState] The object does not have an event named ".concat(eventName));
-    function removeHandler() {
-        removeEventFunc.call(obj, setVal);
-    }
+    var _a = (0, hooks_1.useState)({ value: obj === null || obj === void 0 ? void 0 : obj[propertyName] }), state = _a[0], setState = _a[1];
+    var setValue = (0, hooks_1.useCallback)(function (value) { return setState({ value: value }); }, []);
     (0, hooks_1.useEffect)(function () {
-        setVal(obj[propertyName]);
-        addEventFunc.call(obj, setVal);
+        if (obj == null)
+            return;
+        eventName || (eventName = "On".concat(propertyName, "Changed"));
+        var addEventFunc = obj["add_".concat(eventName)];
+        var removeEventFunc = obj["remove_".concat(eventName)];
+        if (!addEventFunc || !removeEventFunc)
+            throw new Error("[useEventfulState] The object does not have an event named ".concat(eventName));
+        setValue(obj[propertyName]);
+        addEventFunc.call(obj, setValue);
         onEngineReload(removeHandler);
         return function () {
             removeHandler();
             unregisterOnEngineReload(removeHandler);
         };
+        function removeHandler() {
+            removeEventFunc.call(obj, setValue);
+        }
     }, [obj]);
     var setValWrapper = (0, hooks_1.useCallback)(function (v) {
+        if (obj == null)
+            return;
         obj[propertyName] = v;
     }, [obj]);
-    return [val, setValWrapper];
+    return [state.value, setValWrapper];
 }
 exports.useEventfulState = useEventfulState;
 function useEvent(obj, eventName, callback, dependencies) {
     if (dependencies === void 0) { dependencies = []; }
-    function removeHandler() {
-        obj["remove_".concat(eventName)](callback);
-    }
     (0, hooks_1.useEffect)(function () {
+        if (obj == null)
+            return;
         obj["add_".concat(eventName)](callback);
         onEngineReload(removeHandler);
         return function () {
             removeHandler();
             unregisterOnEngineReload(removeHandler);
         };
+        function removeHandler() {
+            obj["remove_".concat(eventName)](callback);
+        }
     }, dependencies);
 }
 exports.useEvent = useEvent;

--- a/onejs/index.ts
+++ b/onejs/index.ts
@@ -1,10 +1,6 @@
-import {
-    MutableRef,
-    StateUpdater,
-    useCallback,
-    useEffect,
-    useState,
-} from "preact/hooks"
+import { Dom } from "OneJS/Dom"
+import { VisualElement } from "UnityEngine/UIElements"
+import { MutableRef, StateUpdater, useCallback, useEffect, useState } from "preact/hooks"
 
 /**
  * A convenience hook that, like useState(), returns a stateful value and a function to update it.
@@ -19,49 +15,55 @@ import {
  */
 export function useEventfulState<
     T extends {
-        [k in K | `add_${E}` | `remove_${E}`]: k extends
-            | `add_${E}`
-            | `remove_${E}`
+        [k in K | `add_${E}` | `remove_${E}`]: k extends `add_${E}` | `remove_${E}`
             ? (handler: (value: T[K]) => any) => void
             : any
     },
     K extends string & keyof T,
     E extends string = `On${K}Changed`
 >(obj: T, propertyName: K, eventName?: E): [T[K], StateUpdater<T[K]>] {
-    const [val, setVal] = useState<T[K]>(obj[propertyName])
-
-    eventName ||= `On${propertyName}Changed` as E
-    const addEventFunc = obj[`add_${eventName}`]
-    const removeEventFunc = obj[`remove_${eventName}`]
-
-    if (!addEventFunc || !removeEventFunc)
-        throw new Error(
-            `[useEventfulState] The object does not have an event named ${eventName}`
-        )
-
-    function removeHandler() {
-        removeEventFunc.call(obj, setVal)
-    }
+    // Guarantee the component is re-rendered on changed event,
+    //  by ensuring that the state is always updated with a different identity
+    //  to handle the case where the object property is an array
+    //  and the changed event is raised with the same array instance.
+    const [state, setState] = useState({ value: obj?.[propertyName] })
+    const setValue = useCallback((value: T[K]) => setState({ value }), [])
 
     useEffect(() => {
-        setVal(obj[propertyName])
-        addEventFunc.call(obj, setVal)
+        if (obj == null) return
+
+        eventName ||= `On${propertyName}Changed` as E
+        const addEventFunc = obj[`add_${eventName}`]
+        const removeEventFunc = obj[`remove_${eventName}`]
+
+        if (!addEventFunc || !removeEventFunc)
+            throw new Error(`[useEventfulState] The object does not have an event named ${eventName}`)
+
+        setValue(obj[propertyName])
+        addEventFunc.call(obj, setValue)
         onEngineReload(removeHandler)
+
         return () => {
             removeHandler()
             unregisterOnEngineReload(removeHandler)
+        }
+
+        function removeHandler() {
+            removeEventFunc.call(obj, setValue)
         }
     }, [obj])
 
     const setValWrapper = useCallback(
         (v: T[K]) => {
+            if (obj == null) return
+
             obj[propertyName] = v
             // setVal(v) // No need to set the state here in JS. The event handling stuff above will do.
         },
         [obj]
     )
 
-    return [val, setValWrapper]
+    return [state.value, setValWrapper]
 }
 
 /**
@@ -75,28 +77,28 @@ export function useEventfulState<
  */
 export function useEvent<
     T extends {
-        [k in `add_${E}` | `remove_${E}`]: (
-            handler: (...args: any) => any
-        ) => void
+        [k in `add_${E}` | `remove_${E}`]: (handler: (...args: any) => any) => void
     },
     E extends string
 >(
     obj: T,
     eventName: E,
-    callback: InferEventHandler<T[`add_${E}`]> &
-        InferEventHandler<T[`remove_${E}`]>,
+    callback: InferEventHandler<T[`add_${E}`]> & InferEventHandler<T[`remove_${E}`]>,
     dependencies: any[] = []
 ) {
-    function removeHandler() {
-        obj[`remove_${eventName}`](callback)
-    }
-
     useEffect(() => {
+        if (obj == null) return
+
         obj[`add_${eventName}`](callback)
         onEngineReload(removeHandler)
+
         return () => {
             removeHandler()
             unregisterOnEngineReload(removeHandler)
+        }
+
+        function removeHandler() {
+            obj[`remove_${eventName}`](callback)
         }
     }, dependencies)
 }
@@ -113,16 +115,15 @@ export function useEvent<
  */
 export function useRefEvent<
     T extends {
-        [k in `add_${E}` | `remove_${E}`]: (
-            handler: (...args: any) => any
-        ) => void
+        [k in `add_${E}` | `remove_${E}` | keyof VisualElement]: k extends `add_${E}` | `remove_${E}`
+            ? (handler: (...args: any) => any) => void
+            : VisualElement[Extract<k, keyof VisualElement>]
     },
     E extends string
 >(
     ref: MutableRef<Dom>,
     eventName: E,
-    callback: InferEventHandler<T[`add_${E}`]> &
-        InferEventHandler<T[`remove_${E}`]>,
+    callback: InferEventHandler<T[`add_${E}`]> & InferEventHandler<T[`remove_${E}`]>,
     dependencies: any[] = []
 ) {
     function removeHandler() {
@@ -142,11 +143,7 @@ export function useRefEvent<
     }, dependencies)
 }
 
-type InferEventHandler<T> = T extends (
-    handler: (...args: infer P) => infer R
-) => void
-    ? (...args: P) => R
-    : never
+type InferEventHandler<T> = T extends (handler: (...args: infer P) => infer R) => void ? (...args: P) => R : never
 
 /**
  * Describes a C# class or struct that contains a property that is a C# event.
@@ -161,23 +158,14 @@ type InferEventHandler<T> = T extends (
  * For event delegates that take more than one value, see related types
  * `HasCsharpEvent2` and `HasCsharpEvent3`.
  */
-export type HasCsharpEvent<EventName extends string, TVal> = HasCSharpEventBase<
+export type HasCsharpEvent<EventName extends string, TVal> = HasCSharpEventBase<EventName, (val: TVal) => void>
+
+export type HasCsharpEvent2<EventName extends string, TVal1, TVal2> = HasCSharpEventBase<
     EventName,
-    (val: TVal) => void
+    (val1: TVal1, val2: TVal2) => void
 >
 
-export type HasCsharpEvent2<
-    EventName extends string,
-    TVal1,
-    TVal2
-> = HasCSharpEventBase<EventName, (val1: TVal1, val2: TVal2) => void>
-
-export type HasCsharpEvent3<
-    EventName extends string,
-    TVal1,
-    TVal2,
-    TVal3
-> = HasCSharpEventBase<
+export type HasCsharpEvent3<EventName extends string, TVal1, TVal2, TVal3> = HasCSharpEventBase<
     EventName,
     (val1: TVal1, val2: TVal2, val3: TVal3) => void
 >
@@ -190,10 +178,7 @@ export type HasCsharpEvent3<
  * - a C# event named `On{PropertyName}Changed`, whose delegate accepts a single
  *   parameter of the same type as the property
  */
-export type HasEventfulProperty<PropName extends string, TVal> = Record<
-    PropName,
-    TVal
-> &
+export type HasEventfulProperty<PropName extends string, TVal> = Record<PropName, TVal> &
     HasCsharpEvent<`On${Capitalize<PropName>}Changed`, TVal>
 
 type HasCSharpEventBase<EventName extends string, TCallback> = Record<


### PR DESCRIPTION
+ Guarantee the component is re-rendered on changed event, by ensuring that the state is always updated with a different identity to handle the case where the object property is an array and the changed event is raised with the same array instance.
+ Handle `obj` being `null` in `useEventfulState` and `useEvent`.
+ Fix `useRefEvent` typing to use the actual `Dom` from `OneJS/Dom`.