### PR TITLE
preact: allow assigning function properties to DOM elements

### DIFF
--- a/3rdparty/preact/diff/props.ts
+++ b/3rdparty/preact/diff/props.ts
@@ -139,9 +139,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		// amount of exceptions would cost us too many bytes. On top of
 		// that other VDOM frameworks also always stringify `false`.
 
-		if (typeof value === 'function') {
-			// never serialize functions as attribute values
-		} else if (name == "disabled") { // MODDED
+		if (name == "disabled") { // MODDED
 			dom.setAttribute(name, value);
 		} else if (value != null && (value !== false || name[4] === '-')) {
 			dom.setAttribute(name, value);


### PR DESCRIPTION
This change allows [P]React code to pass function-valued props to underlying DOM objects (`VisualElement`s). This is in service of custom `VisualElement` classes that can register callbacks into JS code. The callbacks all have the type `Func<JsValue, JsValue[], JsValue>`; i.e., a callable that takes a `this` argument and an array of normal arguments, and returns a `JsValue`.

One thing to consider before we merge this change is that any C# code that depends on this change will be tied to Jint types, which are of course not forward-compatible with any future migration to a different JS runtime. An alternative implementation might include a OneJS-specific wrapper that represents the callable to client C# code as `Func<object, object[], object>`. It would require some reflection magic so I'm not doing it up front, but let me know if this seems like a better approach and I can take a look.