### PR TITLE
Transition.d.ts should extend EventBase

### DIFF
--- a/definitions/UnityEngine/UIElements/Events/Transition.d.ts
+++ b/definitions/UnityEngine/UIElements/Events/Transition.d.ts
@@ -2,7 +2,7 @@
 
 declare module "UnityEngine/UIElements" {
 
-    export class TransitionEventBase {
+    export class TransitionEventBase extends EventBase {
         stylePropertyNames: StylePropertyNameCollection
         elapsedTime: number
     }


### PR DESCRIPTION
Unity transition events seem to have some [weird generic inheritance hierarchy](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/UIElements.TransitionEventBase_1.html), but at the root of it is `EventBase`. This change updates the OneJS type definitions so basic event properties are available via transition events.