### PR TITLE
preact: fix spurious cyclical reference in preact diff

### DIFF
--- a/3rdparty/preact/diff/index.ts
+++ b/3rdparty/preact/diff/index.ts
@@ -518,7 +518,7 @@ export function unmount(vnode, parentVNode, skipRemove = false) {
 	if (options.unmount) options.unmount(vnode);
 
 	if ((r = vnode.ref)) {
-		if (!r.current || r.current === vnode._dom) {
+		if (r.current !== null || r.current === vnode._dom) { // MODDED: s/!r.current/r.current !== null/
 			applyRef(r, null, parentVNode);
 		}
 	}


### PR DESCRIPTION
For some ref-passing scenarios, a falsey-checking expression such as `!r.current` causes Jint to throw spurious cyclic reference exception to be thrown. This seems to be a pattern for a lot of Preact code, so this PR makes a similar update, replacing a falsey check with an explicit null check.

I wasn't able to come up with a simple repro case for this, but I'm assuming the code in the PR is a more accurate reflection of the intent behind `!r.current`.