### PR TITLE
update HasCsharpEvent family of utility types

### DIFF
--- a/onejs/index.ts
+++ b/onejs/index.ts
@@ -114,16 +114,36 @@ export function useRefEvent<T extends VisualElement, E extends OneJS.EventKeys<T
  * For event delegates that take more than one value, see related types
  * `HasCsharpEvent2` and `HasCsharpEvent3`.
  */
-export type HasCsharpEvent<EventName extends string, TVal> = HasCSharpEventBase<EventName, (val: TVal) => void>
+type HasCSharpEventBase<
+  EventName extends string,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  TCallback extends Function
+> = Record<`${EventName}`, OneJS.Event<TCallback>>
 
-export type HasCsharpEvent2<EventName extends string, TVal1, TVal2> = HasCSharpEventBase<
-    EventName,
-    (val1: TVal1, val2: TVal2) => void
+export type HasCsharpEvent0<EventName extends string> = HasCSharpEventBase<
+  EventName,
+  () => void
 >
 
-export type HasCsharpEvent3<EventName extends string, TVal1, TVal2, TVal3> = HasCSharpEventBase<
-    EventName,
-    (val1: TVal1, val2: TVal2, val3: TVal3) => void
+export type HasCsharpEvent<EventName extends string, TVal> = HasCSharpEventBase<
+  EventName,
+  (val: TVal) => void
+>
+
+export type HasCsharpEvent2<
+  EventName extends string,
+  TVal1,
+  TVal2
+> = HasCSharpEventBase<EventName, (val1: TVal1, val2: TVal2) => void>
+
+export type HasCsharpEvent3<
+  EventName extends string,
+  TVal1,
+  TVal2,
+  TVal3
+> = HasCSharpEventBase<
+  EventName,
+  (val1: TVal1, val2: TVal2, val3: TVal3) => void
 >
 
 /**
@@ -136,8 +156,3 @@ export type HasCsharpEvent3<EventName extends string, TVal1, TVal2, TVal3> = Has
  */
 export type HasEventfulProperty<PropName extends string, TVal> = Record<PropName, TVal> &
     HasCsharpEvent<`On${Capitalize<PropName>}Changed`, TVal>
-
-type HasCSharpEventBase<EventName extends string, TCallback> = Record<
-    `add_${EventName}` | `remove_${EventName}`,
-    (handler: TCallback) => void
->


### PR DESCRIPTION
PR #21 changed way JS->C# event subscriptions worked. Instead of directly calling the `add_X` and `remove_X` methods on event objects, event subscriptions are handled in a special `onejs.subscrbe` method to ensure proper cleanup when the engine shuts down.

This PR modernizes the type definitions for the `HasCsharpEvent` family of types so they conform to the new `onejs.subscribe` interface.

FYI: this PR does not contain updates to the .js files, since there doesn't seem to be a tsconfig in this repo. In our project, we compile ScriptLib from .ts files using esbuild, so the .js files aren't necessary.